### PR TITLE
21-do-not-erase-existing-keys-when-enabling-removing-missing-keys

### DIFF
--- a/src/Commands/Translate.php
+++ b/src/Commands/Translate.php
@@ -69,7 +69,7 @@ final class Translate extends Command
 
             // Get final keys
             $newKeys = self::shouldRemoveMissingKeys()
-                ? $foundKeys
+                ? self::removeMissingKeys($currentKeys, $foundKeys)
                 : $foundKeys->merge($currentKeys);
 
             // Sort keys if needed
@@ -174,7 +174,7 @@ final class Translate extends Command
     }
 
     /**
-     * @return Collection<int, string>
+     * @return Collection<string, string>
      */
     private function getLangKeys(string $lang): Collection
     {
@@ -354,7 +354,7 @@ final class Translate extends Command
     }
 
     /**
-     * @param Collection<int, string> $currentKeys
+     * @param Collection<string, string> $currentKeys
      * @param Collection<string, string> $newKeys
      *
      * @return Collection<string, string>
@@ -362,5 +362,26 @@ final class Translate extends Command
     private static function getKeyThatWillBeAdded(Collection $currentKeys, Collection $newKeys): Collection
     {
         return $newKeys->diffKeys($currentKeys);
+    }
+
+    /**
+     * @param Collection<string, string> $currentKeys
+     * @param Collection<string, string> $newKeys
+     *
+     * @return Collection<string, string>
+     */
+    private static function removeMissingKeys(Collection $currentKeys, Collection $newKeys): Collection
+    {
+        return $newKeys->mapWithKeys(function (string $value, string $key) use ($currentKeys): array {
+            if ($currentKeys->has($key)) {
+                return [
+                    $key => $currentKeys->get($key) ?? $value,
+                ];
+            }
+
+            return [
+                $key => $value,
+            ];
+        });
     }
 }

--- a/tests/Feature/Commands/TranslateTest.php
+++ b/tests/Feature/Commands/TranslateTest.php
@@ -646,4 +646,54 @@ final class TranslateTest extends TestCase
             "pagination.next" => "",
         ]);
     }
+
+    public function testDoNotEraseExistingKeysWhenUsingRemoveMissingKeysOption(): void
+    {
+        $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
+
+        $content = json_encode([
+            "Something" => "Quelque chose",
+            "Book saved." => "Livre sauvegardé.",
+            "Book updated." => "Livre mis à jour.",
+            "Deleted :count books." => ":count livres supprimés.",
+            "List of books" => "Liste des livres",
+            "Welcome to the list of books." => "Bienvenue sur la liste des livres.",
+            "This list shows an excerpt of each books." => "Cette lise montre un extrait de chaque livres.",
+            ":count books displayed." => ":count livres affichés.",
+            ":count authors found." => ":count auteur trouvés.",
+            "Unable to perform anti-bot validation." => "Impossible de procéder à la vérification anti-robot.",
+        ], flags: JSON_PRETTY_PRINT);
+
+        assert(is_string($content));
+
+        File::put(__DIR__ . "/../../misc/resources/lang/fr.json", $content);
+
+        config([
+            "translate" => [
+                "remove_missing_keys" => true,
+                "langs" => [
+                    "fr",
+                ],
+                "include" => [
+                    "tests/misc/app",
+                    "tests/misc/resources/views",
+                ],
+            ],
+        ]);
+
+        $this->artisan(Translate::class)
+            ->assertSuccessful();
+
+        $this->assertFileContainsJson(__DIR__ . "/../../misc/resources/lang/fr.json", [
+            "Book saved." => "Livre sauvegardé.",
+            "Book updated." => "Livre mis à jour.",
+            "Deleted :count books." => ":count livres supprimés.",
+            "List of books" => "Liste des livres",
+            "Welcome to the list of books." => "Bienvenue sur la liste des livres.",
+            "This list shows an excerpt of each books." => "Cette lise montre un extrait de chaque livres.",
+            ":count books displayed." => ":count livres affichés.",
+            ":count authors found." => ":count auteur trouvés.",
+            "Unable to perform anti-bot validation." => "Impossible de procéder à la vérification anti-robot.",
+        ]);
+    }
 }


### PR DESCRIPTION
## Added

N/A

## Fixed

- Existing keys will be preserved as expected when using the "remove_missing_keys" option

## Breaking

N/A