### PR TITLE
27-display-added-keys-sentence-in-conditional-when-using-dry-run

### DIFF
--- a/src/Commands/Translate.php
+++ b/src/Commands/Translate.php
@@ -90,7 +90,11 @@ final class Translate extends Command
         $this->line("");
 
         // Display number of added keys (without taking into account current keys)
-        $this->info("Added {$addedKeys->count()} new key(s) on each lang files.");
+        if ($this->shouldWriteOnFile()) {
+            $this->info("Added {$addedKeys->count()} new key(s) on each lang files.");
+        } else {
+            $this->info("{$addedKeys->count()} key(s) would have been added (using --dry-run) on each lang files.");
+        }
 
         // In dry-run mode, return non-zero code if some missing keys have been found
         return !$this->shouldWriteOnFile() && $addedKeys->isNotEmpty()

--- a/tests/Feature/Commands/TranslateTest.php
+++ b/tests/Feature/Commands/TranslateTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Commands;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Testing\PendingCommand;
 use Khalyomede\LaravelTranslate\Commands\Translate;
 use Tests\Misc\App\Models\BookType;
 use Tests\Misc\Database\Seeders\BookTypeSeeder;
@@ -619,6 +620,32 @@ final class TranslateTest extends TestCase
         $this->artisan(Translate::class)
             ->assertSuccessful()
             ->expectsOutputToContain("Added 1 new key(s) on each lang files.");
+    }
+
+    public function testDisplayNumberOfKeysInConditionalIfNewKeysHaveBeenFoundWhenUsingDryRunOption(): void
+    {
+        $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
+
+        config([
+            "translate" => [
+                "remove_missing_keys" => true,
+                "langs" => [
+                    "fr",
+                ],
+                "include" => [
+                    "tests/misc/app",
+                    "tests/misc/resources/views",
+                ],
+            ],
+        ]);
+
+        $command = $this->artisan(Translate::class, [
+            "--dry-run" => true,
+        ]);
+
+        assert($command instanceof PendingCommand);
+
+        $command->expectsOutputToContain("9 key(s) would have been added (using --dry-run) on each lang files.");
     }
 
     public function testDoesNotAddShortKeys(): void


### PR DESCRIPTION
## Added

- New key added sentence will be on conditional when using `--dry-run` option

## Fixed

N/A

## Breaking

N/A