### PR TITLE
25-detect-translations-from-binded-values-on-blade-x-components

### DIFF
--- a/src/Commands/Translate.php
+++ b/src/Commands/Translate.php
@@ -204,8 +204,7 @@ final class Translate extends Command
         $phpParser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $phpTraverser = new NodeTraverser();
 
-        $phpTraverser->addVisitor(new class() extends NodeVisitorAbstract
-        {
+        $phpTraverser->addVisitor(new class () extends NodeVisitorAbstract {
             public function leaveNode(Node $node)
             {
                 if ($node instanceof FuncCall && $node->name instanceof Name && collect(["__", "trans", "trans_choice"])->contains($node->name->parts[0])) {
@@ -258,7 +257,7 @@ final class Translate extends Command
                             $nodeContents = collect();
 
                             $parameters = $node->getParameters()
-                                ->filter(fn (ParameterNode $node): bool => $node->type->name === "DynamicVariable");
+                                ->filter(fn (mixed $node): bool => $node instanceof ParameterNode && $node->type->name === "DynamicVariable");
 
                             foreach ($parameters as $parameter) {
                                 assert($parameter instanceof ParameterNode);

--- a/tests/Feature/Commands/TranslateTest.php
+++ b/tests/Feature/Commands/TranslateTest.php
@@ -66,14 +66,18 @@ final class TranslateTest extends TestCase
         $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
 
         $content = json_encode([
-            ":count authors found." => "",
-            ":count books displayed." => "",
             "Book saved." => "",
             "Book updated." => "",
             "Deleted :count books." => "",
+            "Enter your informations" => "",
+            "Home" => "",
+            "Password reset" => "",
+            "Email address" => "",
             "List of books" => "",
-            "This list shows an excerpt of each books." => "",
             "Welcome to the list of books." => "",
+            "This list shows an excerpt of each books." => "",
+            ":count books displayed." => "",
+            ":count authors found." => "",
             "Unable to perform anti-bot validation." => "",
         ], flags: JSON_PRETTY_PRINT);
 
@@ -583,7 +587,7 @@ final class TranslateTest extends TestCase
 
         $this->artisan(Translate::class)
             ->assertSuccessful()
-            ->expectsOutputToContain("Added 9 new key(s) on each lang files.");
+            ->expectsOutputToContain("Added 13 new key(s) on each lang files.");
     }
 
     public function testDisplayOnlyNewKeysAddedToFileWithoutTakingIntoAccountCurrentExistingKeys(): void
@@ -594,6 +598,10 @@ final class TranslateTest extends TestCase
             "Book saved." => "",
             "Book updated." => "",
             "Deleted :count books." => "",
+            "Enter your informations" => "",
+            "Home" => "",
+            "Password reset" => "",
+            "Email address" => "",
             "List of books" => "",
             "Welcome to the list of books." => "",
             "This list shows an excerpt of each books." => "",
@@ -645,7 +653,7 @@ final class TranslateTest extends TestCase
 
         assert($command instanceof PendingCommand);
 
-        $command->expectsOutputToContain("9 key(s) would have been added (using --dry-run) on each lang files.");
+        $command->expectsOutputToContain("13 key(s) would have been added (using --dry-run) on each lang files.");
     }
 
     public function testDoesNotAddShortKeys(): void
@@ -746,6 +754,29 @@ final class TranslateTest extends TestCase
 
         $this->assertFileDoesntContainJson(__DIR__ . "/../../misc/resources/lang/fr.json", [
             "" => "",
+        ]);
+    }
+
+    public function testCanPullNewKeysFromBladeBindedValues(): void
+    {
+        $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
+
+        config([
+            "translate" => [
+                "langs" => [
+                    "fr",
+                ],
+                "include" => [
+                    "tests/misc/resources/views/account",
+                ],
+            ],
+        ]);
+
+        $this->artisan(Translate::class)
+            ->assertSuccessful();
+
+        $this->assertFileContainsJson(__DIR__ . "/../../misc/resources/lang/fr.json", [
+            "Enter your informations" => "",
         ]);
     }
 }

--- a/tests/misc/resources/views/account/edit.blade.php
+++ b/tests/misc/resources/views/account/edit.blade.php
@@ -1,0 +1,5 @@
+@extends('layout.logged')
+
+@section('content')
+    <x-form :title="__('Enter your informations')"></x-form>
+@endsection


### PR DESCRIPTION
## Added

- Blade binded attributes (like `<x-form :title="__('Enter your informations')"></x-form>` will now be parsed when pulling new keys

## Fixed

N/A

## Breaking

N/A