### PR TITLE
37-php-code-containing-function-call-is-considered-a-valid-translation-key

### DIFF
--- a/tests/Feature/Commands/TranslateTest.php
+++ b/tests/Feature/Commands/TranslateTest.php
@@ -846,7 +846,7 @@ final class TranslateTest extends TestCase
         ]);
     }
 
-    public function testDoesNotTranslatePhpCodeKeys(): void
+    public function testDoesNotPullTranslationKeyCorrespondingToPhpCodeKeys(): void
     {
         $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
 
@@ -866,6 +866,7 @@ final class TranslateTest extends TestCase
 
         $this->assertFileDoesntContainJson(__DIR__ . "/../../misc/resources/lang/fr.json", [
             '$user->type' => "",
+            'ucfirst($user->type)' => "",
         ]);
     }
 }

--- a/tests/misc/resources/views/password-forgotten/create.blade.php
+++ b/tests/misc/resources/views/password-forgotten/create.blade.php
@@ -2,4 +2,5 @@
 
 @section('content')
     @lang($user->type)
+    @lang(ucfirst($user->type))
 @endsection


### PR DESCRIPTION
## Added

N/A

## Fixed

- Keys corresponding to PHP function call will not be pulled as new translation keys

## Breaking

N/A