### PR TITLE
9-add-ability-to-provide-a-list-of-arrayable-classes-to-be-translated

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ php artisan vendor:publish --tag "translate"
 - [3. Customize which folders to parse](#3-customize-which-folders-to-parse)
 - [4. Remove translation keys not found](#4-remove-translation-keys-not-found)
 - [5. Translate models data](#5-translate-models-data)
+- [6. Add raw array of keys](#6-add-raw-array-of-keys)
 
 ### 1. Check for missing translations
 
@@ -161,6 +162,51 @@ This assumes you translate your model like this for example:
     <option value="{{ $userType->id }}>@lang($userType->name)</option>
   @endforeach
 </select>
+```
+
+### 6. Add raw array of keys
+
+When you have something translation keys not in an Eloquent model nor a hard-coded string like `@lang("Hello world")`, but you still want to include it in the list of translation keys, you can build a custom array or Collection to give to the command.
+
+Add it like this in your "config/translate.php" file:
+
+```php
+use App\Constants\InvoiceStatus;
+
+return [
+  // ...
+  "translatables" => [
+    fn () => [ InvoiceStatus::PENDING, InvoiceStatus::SENT, InvoiceStatus::PAID ],
+  ]
+];
+```
+
+You can also return a Collection if you prefer:
+
+```php
+use App\Constants\InvoiceStatus;
+
+return [
+  // ...
+  "translatables" => [
+    fn () => collect([InvoiceStatus::PENDING, InvoiceStatus::SENT, InvoiceStatus::PAID]),
+  ]
+];
+```
+
+You can have more than one translatable:
+
+```php
+use App\Constants\InvoiceStatus;
+use App\Enums\UserRole;
+
+return [
+  // ...
+  "translatables" => [
+    fn () => collect(InvoiceStatus::PENDING, InvoiceStatus::SENT, InvoiceStatus::PAID]),
+    fn () => collect(UserRole::cases())->map(fn (UserRole $userRole): string => $userRole->toString()),
+  ]
+];
 ```
 
 ## Tests

--- a/src/Commands/Translate.php
+++ b/src/Commands/Translate.php
@@ -459,6 +459,7 @@ final class Translate extends Command
                 return false;
             })
             ->diff(self::keysToIgnore())
+            ->concat(self::translatableKeys())
             ->flip()
             ->mapWithKeys(fn (int $key, string $value): array => [
                 $value => "",
@@ -573,5 +574,28 @@ final class Translate extends Command
     private static function getMaxMemoryInMegaBytes(): string
     {
         return round((memory_get_peak_usage(true) / 1_024) / 1_024, 2) . " Mb";
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private static function translatableKeys(): Collection
+    {
+        $translatables = config("translate.translatables");
+
+        assert(is_array($translatables));
+
+        /**
+         * @var Collection<int, string>
+         */
+        return collect($translatables)
+            ->map(function (callable $callback): Collection {
+                $keys = call_user_func($callback);
+
+                assert(is_array($keys));
+
+                return collect($keys);
+            })
+            ->flatten();
     }
 }

--- a/src/config/translate.php
+++ b/src/config/translate.php
@@ -10,4 +10,5 @@ return [
     ],
     "models" => [],
     "ignore_keys" => [],
+    "translatables" => [],
 ];

--- a/tests/Feature/Commands/TranslateTest.php
+++ b/tests/Feature/Commands/TranslateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Commands;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Testing\PendingCommand;
 use Khalyomede\LaravelTranslate\Commands\Translate;
@@ -937,5 +938,31 @@ final class TranslateTest extends TestCase
             ->assertSuccessful()
             ->expectsOutputToContain("Time:")
             ->expectsOutputToContain("Max memory:");
+    }
+
+    public function testCanAddKeysFromTranslatables(): void
+    {
+        $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
+
+        config([
+            "translate" => [
+                "langs" => [
+                    "fr",
+                ],
+                "include" => [],
+                "translatables" => [
+                    fn (): Collection => collect(["Red", "Blue", "Yellow"]),
+                ]
+            ],
+        ]);
+
+        $this->artisan(Translate::class)
+            ->assertSuccessful();
+
+        $this->assertFileContainsJson(__DIR__ . "/../../misc/resources/lang/fr.json", [
+            "Red" => "",
+            "Blue" => "",
+            "Yellow" => "",
+        ]);
     }
 }


### PR DESCRIPTION
## Added

- New `translatables` config key to pass callbacks that return arrays (or Collection) including arbitrary translation keys

## Fixed

N/A

## Breaking

N/A