### PR TITLE
49-translation-texts-starting-with-new-not-translated 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The command will not hang a few seconds without showing progress anymore ([#46](https://github.com/khalyomede/laravel-translate/issues/46)).
+- Texts starting with "New" will now be correctly translated ([#49](https://github.com/khalyomede/laravel-translate/issues/49)).
 
 ## [0.1.0] - 2023-03-25
 

--- a/src/Commands/Translate.php
+++ b/src/Commands/Translate.php
@@ -7,11 +7,13 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
@@ -477,7 +479,8 @@ final class Translate extends Command
                     return false;
                 }
 
-                if ($expression->expr instanceof ConstFetch) {
+                // instanceof New -> "New account", "New" is parsed as new class keyword
+                if ($expression->expr instanceof ConstFetch || $expression->expr instanceof New_) {
                     $bar->advance();
 
                     return true;

--- a/tests/Feature/Commands/TranslateTest.php
+++ b/tests/Feature/Commands/TranslateTest.php
@@ -88,6 +88,7 @@ final class TranslateTest extends TestCase
             "test 2" => "",
             "test 3" => "",
             "Unable to perform anti-bot validation." => "",
+            "New journey" => "",
         ], flags: JSON_PRETTY_PRINT);
 
         assert(is_string($content));
@@ -598,7 +599,7 @@ final class TranslateTest extends TestCase
 
         $this->artisan(Translate::class)
             ->assertSuccessful()
-            ->expectsOutputToContain("Added 21 new key(s) on each lang files.");
+            ->expectsOutputToContain("Added 22 new key(s) on each lang files.");
     }
 
     public function testDisplayOnlyNewKeysAddedToFileWithoutTakingIntoAccountCurrentExistingKeys(): void
@@ -626,6 +627,7 @@ final class TranslateTest extends TestCase
             "test" => "",
             "test 2" => "",
             "test 3" => "",
+            "New journey" => "",
         ], flags: JSON_PRETTY_PRINT);
 
         assert(is_string($content));
@@ -672,7 +674,7 @@ final class TranslateTest extends TestCase
 
         assert($command instanceof PendingCommand);
 
-        $command->expectsOutputToContain("21 key(s) would have been added (using --dry-run) on each lang files.");
+        $command->expectsOutputToContain("22 key(s) would have been added (using --dry-run) on each lang files.");
     }
 
     public function testDoesNotAddShortKeys(): void
@@ -915,7 +917,7 @@ final class TranslateTest extends TestCase
 
         $this->artisan(Translate::class)
             ->assertSuccessful()
-            ->expectsOutputToContain("12/12");
+            ->expectsOutputToContain("13/13");
     }
 
     public function testDisplaysElapsedTimeAndMaxMemoryConsumption(): void
@@ -963,6 +965,29 @@ final class TranslateTest extends TestCase
             "Red" => "",
             "Blue" => "",
             "Yellow" => "",
+        ]);
+    }
+
+    public function testCanTranslateTextStartingWithNew(): void
+    {
+        $this->app?->useLangPath(__DIR__ . "/../../misc/resources/lang");
+
+        config([
+            "translate" => [
+                "langs" => [
+                    "fr",
+                ],
+                "include" => [
+                    "tests/misc/resources/views/about-us"
+                ],
+            ],
+        ]);
+
+        $this->artisan(Translate::class)
+            ->assertSuccessful();
+
+        $this->assertFileContainsJson(__DIR__ . "/../../misc/resources/lang/fr.json", [
+            "New journey" => "",
         ]);
     }
 }

--- a/tests/misc/resources/views/about-us/index.blade.php
+++ b/tests/misc/resources/views/about-us/index.blade.php
@@ -1,0 +1,1 @@
+<h1>@lang('New journey')</h1>


### PR DESCRIPTION
## Added

N/A

## Fixed

- Texts starting with "New" will now be correctly translated.

## Breaking

N/A